### PR TITLE
Ddd method to Query to be able to retrieve the Values

### DIFF
--- a/session.go
+++ b/session.go
@@ -935,6 +935,12 @@ func (q Query) Statement() string {
 	return q.stmt
 }
 
+// Values returns the values passed in via Bind. This can be helpful for wrapping types
+// to not have to keep track of the values to be able to access them.
+func (q Query) Values() []interface{} {
+	return q.values
+}
+
 // String implements the stringer interface.
 func (q Query) String() string {
 	return fmt.Sprintf("[query statement=%q values=%+v consistency=%s]", q.stmt, q.values, q.cons)


### PR DESCRIPTION
In the context of gocql itself there is little point for this method. But when building wrappers for `Query` the `values` cannot be accessed by the wrapper. This becomes interesting for wrappers that implement functionality like `BindStruct`. A wrapper would need to keep track of the `values` itself. While this is possible, a wrapper of a wrapper cannot access the values any more if neither qocql nor the wrapper expose them.

This little addition to the library would help significantly in the creation of custom build wrappers that want to rely on the stability of this package as a foundation.